### PR TITLE
prg: Fix a bug in `convert()` (main)

### DIFF
--- a/src/prg.rs
+++ b/src/prg.rs
@@ -113,8 +113,8 @@ impl PrgSeed {
             s.fill_bytes(&mut out.seed.key);
             unsafe {
                 let sp = s_in.as_ptr();
-                for i in 0..input_len {
-                    out.word[i].from_rng(&mut *sp);
+                for x in out.word.iter_mut() {
+                    x.from_rng(&mut *sp);
                 }
             }
         });


### PR DESCRIPTION
Previously we were generating a correction word that was only partially pseudorandom. In particular, the last element of the vector (the counter value in Mastic) was set to `0`. This allows an attacker to easily deduce if a given prefix is on path or off path.