### PR TITLE
prg: Fix a bug in `convert()` (histograms)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ bincode = "1.3.3"
 blake3 = { version = "1.5.0", features = ["rayon"]}
 clap = "2.0"
 ctr = "0.9.2"
+cfg-if = "1.0.0"
 futures = "0.3.28"
 getrandom = { version = "0.2.10", features = ["std"] }
 itertools = "0.10.5"

--- a/src/prg.rs
+++ b/src/prg.rs
@@ -103,8 +103,8 @@ impl PrgSeed {
             s.fill_bytes(&mut out.seed.key);
             unsafe {
                 let sp = s_in.as_ptr();
-                for i in 0..input_len {
-                    out.word[i].from_rng(&mut *sp);
+                for x in out.word.iter_mut() {
+                    x.from_rng(&mut *sp);
                 }
             }
         });


### PR DESCRIPTION
﻿Same as #3 but for the histograms branch.

While at it, make sure the code builds on aarch64.