### PR TITLE
Implement attribute-based metrics

### DIFF
--- a/src/bin/config.json
+++ b/src/bin/config.json
@@ -2,8 +2,8 @@
     "data_bytes": 1,
     "hist_buckets": 4,
     "mode": {
-        "weighted_heavy_hitters": {
-            "threshold": 0.01
+        "attribute_based_metrics": {
+            "num_attributes": 20
         }
     },
     "server_0": "0.0.0.0:8000",

--- a/src/bin/config.json
+++ b/src/bin/config.json
@@ -1,7 +1,11 @@
 {
     "data_bytes": 1,
     "hist_buckets": 4,
-    "threshold": 0.01,
+    "mode": {
+        "weighted_heavy_hitters": {
+            "threshold": 0.01
+        }
+    },
     "server_0": "0.0.0.0:8000",
     "server_1": "0.0.0.0:8001",
     "add_key_batch_size": 1000,

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,20 @@ use clap::{App, Arg};
 use serde::Deserialize;
 
 #[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Mode {
+    WeightedHeavyHitters {
+        /// The servers will output the collection of strings that more than a `threshold` of
+        /// clients hold.
+        threshold: f64,
+    },
+    AttributedBasedMetrics {
+        /// The set of attributes used by the servers to group metrics.
+        attributes: Vec<()>,
+    },
+}
+
+#[derive(Deserialize)]
 pub struct Config {
     /// Number of bytes of each string (x8 for bits).
     pub data_bytes: usize,
@@ -21,9 +35,8 @@ pub struct Config {
     /// Number of distinct strings.
     pub unique_buckets: usize,
 
-    /// The servers will output the collection of strings that more than a `threshold` of clients
-    /// hold.
-    pub threshold: f64,
+    /// Mode of operation in which to use Mastic.
+    pub mode: Mode,
 
     /// Each simulated client samples its private string from a Zipf distribution over strings with
     /// parameter `zipf_exponent`

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,17 +3,23 @@ use std::{fs, net::SocketAddr};
 use clap::{App, Arg};
 use serde::Deserialize;
 
+/// Parameters used by the driver program to generate test data.
 #[derive(Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Mode {
+    /// Simulate weighted heavy hitters. In this mode, the aggregators compute the subset of inputs
+    /// whose total weight exceed a given threshold.
     WeightedHeavyHitters {
-        /// The servers will output the collection of strings that more than a `threshold` of
-        /// clients hold.
+        /// The weighted heavy hitters threshold.
         threshold: f64,
     },
-    AttributedBasedMetrics {
-        /// The set of attributes used by the servers to group metrics.
-        attributes: Vec<()>,
+
+    /// Simulate attribute-based metrics. In this mode, the aggregators agree on a set of
+    /// attributes to use to partition the metrics.
+    AttributeBasedMetrics {
+        /// For testing purposes, the driver will sample `num_attributes` inputs from the same
+        /// distribution as the clients.
+        num_attributes: usize,
     },
 }
 
@@ -32,14 +38,13 @@ pub struct Config {
     /// Similar to `add_key_batch_size` but with a greater threshold.
     pub flp_batch_size: usize,
 
-    /// Number of distinct strings.
+    /// Zipf parameter: Number of distinct strings.
     pub unique_buckets: usize,
 
-    /// Mode of operation in which to use Mastic.
+    /// Mode of operation in which to test Mastic.
     pub mode: Mode,
 
-    /// Each simulated client samples its private string from a Zipf distribution over strings with
-    /// parameter `zipf_exponent`
+    /// Zipf parameter: The distribution from which each client chooses its input.
     pub zipf_exponent: f64,
 
     /// The `IP:port` tuple for server 0.

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -59,6 +59,21 @@ pub struct TreePruneRequest {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct FinalSharesRequest {}
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AggregateByAttributesValidateRequest {
+    pub attributes: Vec<String>,
+    pub start: usize,
+    pub end: usize,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AggregateByAttributesResultRequest {
+    pub rejected: Vec<usize>,
+    pub num_attributes: usize,
+    pub start: usize,
+    pub end: usize,
+}
+
 #[tarpc::service]
 pub trait Collector {
     /// Initialize the tree (single root that has all the clients keys and values).
@@ -95,4 +110,17 @@ pub trait Collector {
 
     /// Get the final paths and secret shared values.
     async fn final_shares(req: FinalSharesRequest) -> Vec<collect::Result>;
+
+    /// For the subset of reports indicated by the caller, evaluate the VIDPF key on the provided set
+    /// of attributes and return the VIDPF proof and FLP verifier share.
+    async fn aggregate_by_attributes_start(
+        req: AggregateByAttributesValidateRequest,
+    ) -> Vec<(Vec<Field128>, [u8; blake3::OUT_LEN])>;
+
+    /// For the subset of reports indicated by the caller, compute the aggregate share, rejecting
+    /// the reports indicated by the caller. This method should be called only after calling
+    /// `aggregate_by_attributes_start` on the same set of reports.
+    async fn aggregate_by_attributes_finish(
+        req: AggregateByAttributesResultRequest,
+    ) -> Vec<Vec<Field128>>;
 }


### PR DESCRIPTION
Reimplementation of `fast-start` using new RPCs rather than a new binary for the driver and server.

DO NOT MERGE: once approved, we'll force-push this branch to `fast-start`. The base branch for this PR is `histograms` because that was my starting point.

Review commit by commit. Each commit is meant to be self-contained so that we can cherry-pick the functionality onto other branches if desired.

