### PR TITLE
Add support for Prio3Histogram

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,9 @@ pub enum Mode {
         /// distribution as the clients.
         num_attributes: usize,
     },
+
+    /// Simulate plain metrics, aggregated using Prio3 instead of Mastic.
+    PlainMetrics,
 }
 
 #[derive(Deserialize)]

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1,7 +1,10 @@
 use prio::field::Field128;
 use serde::{Deserialize, Serialize};
 
-use crate::{collect, vidpf, HASH_SIZE};
+use crate::{
+    collect::{self, ReportShare},
+    HASH_SIZE,
+};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ResetRequest {
@@ -10,15 +13,8 @@ pub struct ResetRequest {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct AddKeysRequest {
-    pub keys: Vec<vidpf::VidpfKey>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct AddFLPsRequest {
-    pub flp_proof_shares: Vec<Vec<Field128>>,
-    pub nonces: Vec<[u8; 16]>,
-    pub jr_parts: Vec<[[u8; 16]; 2]>,
+pub struct AddReportSharesRequest {
+    pub report_shares: Vec<ReportShare>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -82,11 +78,8 @@ pub trait Collector {
     /// Reset the collector to its initial state.
     async fn reset(req: ResetRequest) -> String;
 
-    /// Add a batch of keys to the collector.
-    async fn add_keys(req: AddKeysRequest) -> String;
-
-    /// Add a batch of FLP proof shares to the collector.
-    async fn add_all_flp_proof_shares(req: AddFLPsRequest) -> String;
+    /// Add a batch of report shares to the collector.
+    async fn add_report_shares(req: AddReportSharesRequest) -> String;
 
     /// Run FLP proof queries.
     async fn run_flp_queries(req: RunFlpQueriesRequest) -> Vec<Vec<Field128>>;

--- a/tests/collect_test.rs
+++ b/tests/collect_test.rs
@@ -21,8 +21,18 @@ fn collect_test_eval_groups() {
     for cstr in &client_strings {
         let input_beta = mastic.encode_measurement(&2).unwrap();
         let (keys_0, keys_1) = vidpf::VidpfKey::gen_from_str(&cstr, &input_beta);
-        col_0.add_key(keys_0);
-        col_1.add_key(keys_1);
+        col_0.add_report_share(ReportShare::Mastic {
+            nonce: Default::default(), // ignored by test
+            vidpf_key: keys_0,
+            flp_proof_share: Default::default(), // ignored by test
+            flp_joint_rand_parts: Default::default(), // ignored by test
+        });
+        col_1.add_report_share(ReportShare::Mastic {
+            nonce: Default::default(), // ignored by test
+            vidpf_key: keys_1,
+            flp_proof_share: Default::default(), // ignored by test
+            flp_joint_rand_parts: Default::default(), // ignored by test
+        });
     }
 
     col_0.tree_init();
@@ -113,8 +123,18 @@ fn collect_test_eval_full_groups() {
     for i in 0..num_clients {
         let copy_0 = keys[i % keys.len()].0.clone();
         let copy_1 = keys[i % keys.len()].1.clone();
-        col_0.add_key(copy_0);
-        col_1.add_key(copy_1);
+        col_0.add_report_share(ReportShare::Mastic {
+            nonce: Default::default(), // ignored by test
+            vidpf_key: copy_0,
+            flp_proof_share: Default::default(), // ignored by test
+            flp_joint_rand_parts: Default::default(), // ignored by test
+        });
+        col_1.add_report_share(ReportShare::Mastic {
+            nonce: Default::default(), // ignored by test
+            vidpf_key: copy_1,
+            flp_proof_share: Default::default(), // ignored by test
+            flp_joint_rand_parts: Default::default(), // ignored by test
+        });
         if i % 50 == 0 {
             println!("  VIDPFKey {:?}", i);
         }


### PR DESCRIPTION
There are new VDAFs, each with a different report (share) structure. Accommadating this requires some refactoring. In particular, the add_keys() and add_flp_*() RPCs are merged into a single RPC, add_report_shares(), which takes a sequence of ReportShare enums.

While at it, fix a bug in the weighted heavy hitters mode. (We were computing the length of the FLP query randomness incorrectly.)